### PR TITLE
fix issues with compiling php 7.3.7

### DIFF
--- a/source/php-static/pkg.yml
+++ b/source/php-static/pkg.yml
@@ -25,6 +25,7 @@ deps:
   - libjpeg-turbo-dev
   - libmcrypt-dev
   - libpng-dev
+  - libpng-static
   - libssh2-dev
   - libtool
   - libxml2-dev
@@ -39,6 +40,7 @@ deps:
   - sqlite-static
   - unixodbc-dev
   - zlib-dev
+  - libbz2-static
 
 version:
   src: https://secure.php.net/downloads.php


### PR DESCRIPTION
Added libpng-static and libbz2-static pkg.yml to allow compiling php 7.3.7