### PR TITLE
now used local packages for dep resolution

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -84,6 +84,12 @@ fi
 cp -r $DIR/source/$PKG/* $PKGDIR
 cp -r $DIR/lib $PKGDIR
 
+if [ -d $DIR/build ]; then
+mkdir $PKGDIR/local_builds
+cp -r $DIR/build/*${TARGET_ARCH}*.tar.xz $PKGDIR/local_builds 
+cp $DIR/build/SHA512SUMS $PKGDIR/local_builds
+fi
+
 docker pull $docker_image
 
 delete_build() {

--- a/build-static.sh
+++ b/build-static.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-#set -eu
+set -eu
 
 # Current directory
 DIR=$(cd -P $(dirname $0) && pwd)

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -34,7 +34,7 @@ if [ "$(readyaml -f pkg.yml deps static)" ] ;then
   for dep in $(readyaml -f pkg.yml deps static) ;do
     # Download the depencies, listed on SHA512SUMS
     info "Installing $dep"
-    match="${dep}_.*_$SYSTEM.tar.xz"
+    match="${dep}_.*_${TARGET_ARCH}.tar.xz"
     package=$(printf '%b' "$sha512sums\n" | grep -om1 "$match") || error "no package match" "$match"
     wget "$MIRROR/$package" -O $package
 
@@ -45,9 +45,9 @@ if [ "$(readyaml -f pkg.yml deps static)" ] ;then
     esac
     tar xJf $package
     rm $package
-    chown -R 0:0 ${dep}_*_$SYSTEM*
-    cp -rf ${dep}_*_$SYSTEM*/* /usr
-    rm -rf ${dep}_*_$SYSTEM*
+    chown -R 0:0 ${dep}_*_$TARGET_ARCH*
+    cp -rf ${dep}_*_$TARGET_ARCH*/* /usr
+    rm -rf ${dep}_*_$TARGET_ARCH*
   done
 fi
 
@@ -55,7 +55,7 @@ fi
 [ "${ver-}" ] || error 'ver' 'no version number returned'
 
 # Create the directory
-PACKAGE=${PKG}_${ver}_$SYSTEM
+PACKAGE=${PKG}_${ver}_$TARGET_ARCH
 mkdir $PACKAGE
 
 info "Package to build: $PACKAGE"

--- a/source/php-static/pkg.yml
+++ b/source/php-static/pkg.yml
@@ -25,6 +25,7 @@ deps:
   - libjpeg-turbo-dev
   - libmcrypt-dev
   - libpng-dev
+  - libpng-static
   - libssh2-dev
   - libtool
   - libxml2-dev
@@ -39,6 +40,7 @@ deps:
   - sqlite-static
   - unixodbc-dev
   - zlib-dev
+  - libbz2-static
 
 version:
   src: https://secure.php.net/downloads.php


### PR DESCRIPTION
There is a bug in the current implementation that wont use x86 versions of the packages . specifically if you try and compile php x86 it will not resolve dependencies and fail to build. This change set makes the packages now unique  based on the target arch . In addition this will now use a local package if it exists for dependency resolution. 